### PR TITLE
Apologies and version 0.51

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,20 +2,25 @@
 Prowlpy
 =======
 
-Originally Written by Jacob Burch, 7/6/2009
-Modified by Olivier Hervieu
-Updated for Prowl API 1.2 by Ken Pepple, 3/5/2011
+| Originally Written by Jacob Burch, 7/6/2009
+| Modified by Olivier Hervieu
+| Updated for Prowl API 1.2 by Ken Pepple, 3/5/2011
 
 Python module for posting to the iPhone Push Notification service Prowl: http://www.prowlapp.com/
 
 Dependencies:
 =============
 
-No extra dependency. (Prowlpy use only basic python modules)
-The socket module must be compiled with SSL support
+No extra dependency (Prowlpy use only basic python modules).
+
+The socket module must be compiled with SSL support.
 
 Change Log:
 ===========
+
+v0.51
+-----
+- updated return values of retrieve_apikey and retrieve_token
 
 v0.50
 -----

--- a/demos/example-1-2.py
+++ b/demos/example-1-2.py
@@ -35,20 +35,18 @@ Example notification using prowl API v1.2
 """
 import prowlpy
 
-apikey = 'b57501d2e56cfd64316153da47355283db4752fc' # API key
-pkey   = '2b39d3f3f8522aaed4b2fc44357f1519793db6a2' # provider key
+# get a apikey and provider key at https://www.prowlapp.com/api_settings.php
+apikey = 'sdfsdfsdfsdffdfsdf' # insert your API key
+pkey   = 'sfsdfasdfadsfsdfsf' # insert your provider key
 
 p = prowlpy.Prowl(apikey)
 
 # get token for user
-token = p.retrieve_token(pkey)
+response = p.retrieve_token(pkey)
+
+print "I got token %s for %s" % (response['token'], response['url'])
 
 # assuming that the user has accepted your request
+# (they go to the response["url"] via a browser to accept)
 # retrieve his/her apikey
-users_apikey = p.retrieve_apikey(pkey, token)
-
-try:
-    p.add('TestApp','Registration',"You are registered !", 1, None, "http://www.prowlapp.com/")
-    print 'Success'
-except Exception,msg:
-    print msg
+users_apikey = p.retrieve_apikey(pkey, response["token"])

--- a/python/prowlpy.py
+++ b/python/prowlpy.py
@@ -55,7 +55,7 @@ __author__ = 'Jacob Burch'
 __author_email__ = 'jacoburch@gmail.com'
 __maintainer__ = 'Olivier Hervieu'
 __maintainer_email__ = 'olivier.hervieu@gmail.com'
-__version__ = 0.50
+__version__ = 0.51
 
 from httplib import HTTPSConnection as Https
 from urllib import urlencode
@@ -192,6 +192,13 @@ class Prowl(object):
 
         The parameters are :
         - providerkey (required) : your provider API key.
+
+        This returns a dictionary such as:
+        {'code': u'0',
+         'remaining': u'999',
+         'resetdate': u'1299535575',
+         'token': u'60fd568423e3cd337b45172be91cabe46b94c200',
+         'url': u'https://www.prowlapp.com/retrieve.php?token=60fd5684'}
         """
 
         h = Https(API_DOMAIN)
@@ -210,10 +217,23 @@ class Prowl(object):
 
         if request_status == 200:
             dom = minidom.parseString(request.read())
+            code = dom.getElementsByTagName('prowl')[0].\
+                            getElementsByTagName('success')[0].\
+                            getAttribute('code')
+            remaining = dom.getElementsByTagName('prowl')[0].\
+                            getElementsByTagName('success')[0].\
+                            getAttribute('remaining')
+            resetdate = dom.getElementsByTagName('prowl')[0].\
+                            getElementsByTagName('success')[0].\
+                            getAttribute('resetdate')
             token = dom.getElementsByTagName('prowl')[0].\
                         getElementsByTagName('retrieve')[0].\
                         getAttribute('token')
-            return token
+            url = dom.getElementsByTagName('prowl')[0].\
+                      getElementsByTagName('retrieve')[0].\
+                      getAttribute('url')
+            return dict(token=token, url=url, code=code,
+                        remaining=remaining, resetdate=resetdate)
         else:
             self._relay_error(request_status)
 
@@ -225,7 +245,13 @@ class Prowl(object):
 
         The parameters are :
         - providerkey (required) : your provider API key.
-        - token (required): the token returned from retrieve/token.
+        - token (required): the token returned from retrieve_token.
+
+        This returns a dictionary such as:
+        {'apikey': u'16b776682332cf11102b67d6db215821f2c233a3',
+         'code': u'200',
+         'remaining': u'999',
+         'resetdate': u'1299535575'}
         """
 
         h = Https(API_DOMAIN)
@@ -247,7 +273,24 @@ class Prowl(object):
                   "/publicapi/retrieve/apikey?" + urlencode(data),
                   headers=self.headers)
 
-        request_status = h.getresponse().status
+        request = h.getresponse()
+        request_status = request.status
 
-        if request_status != 200:
+        if request_status == 200:
+            dom = minidom.parseString(request.read())
+            code = dom.getElementsByTagName('prowl')[0].\
+                            getElementsByTagName('success')[0].\
+                            getAttribute('code')
+            remaining = dom.getElementsByTagName('prowl')[0].\
+                            getElementsByTagName('success')[0].\
+                            getAttribute('remaining')
+            resetdate = dom.getElementsByTagName('prowl')[0].\
+                            getElementsByTagName('success')[0].\
+                            getAttribute('resetdate')
+            users_api_key = dom.getElementsByTagName('prowl')[0].\
+                                getElementsByTagName('retrieve')[0].\
+                                getAttribute('apikey')
+            return dict(apikey=users_api_key, code=code, remaining=remaining,
+                        resetdate=resetdate)
+        else:
             self._relay_error(request_status)


### PR DESCRIPTION
Apologies for the last pull request. I made the request without pushing my current local repo to github (which is why retrieve_apikey doesn't return the apikey :( ).

Here is the correct version:
- retrieve_token and retrieve_apikey return dictionaries of full prowl server response
- updated example script
- bumped version to 0.51

Sorry again.
